### PR TITLE
fix: Using dual peak sliders doesn't switch display mode

### DIFF
--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -706,7 +706,9 @@ PlasmaAudioProcessorEditor::sliderDragStarted(Slider* slider)
              slider == &highPassResonanceQualitySlider ||
              slider == &highPassSlopeSlider || slider == &peakStereoSlider ||
              slider == &peakFreqSlider || slider == &peakGainSlider ||
-             slider == &peakQualitySlider || slider == &lowPassFreqSlider ||
+             slider == &peakQualitySlider || slider == &dualPeakWidthSlider ||
+             slider == &dualPeakFreqSlider || slider == &dualPeakGainSlider ||
+             slider == &dualPeakQualitySlider || slider == &lowPassFreqSlider ||
              slider == &lowPassResonanceSlider ||
              slider == &lowPassResonanceQualitySlider ||
              slider == &lowPassSlopeSlider) {


### PR DESCRIPTION
Fix a bug introduced in #18